### PR TITLE
Throw correct error when failing to read a tag.

### DIFF
--- a/Sources/LibTIFF/TIFFImage.swift
+++ b/Sources/LibTIFF/TIFFImage.swift
@@ -400,7 +400,7 @@ public struct TIFFAttributes {
                                          UInt32(bitPattern: tag),
                                          &value)
             guard result == 1 else {
-                throw TIFFError.SetField(tag)
+                throw TIFFError.GetField(tag)
             }
             return value as! T
         case is UInt32.Type:
@@ -409,7 +409,7 @@ public struct TIFFAttributes {
                                          UInt32(bitPattern: tag),
                                          &value)
             guard result == 1 else {
-                throw TIFFError.SetField(tag)
+                throw TIFFError.GetField(tag)
             }
             return value as! T
         default:


### PR DESCRIPTION
I had a TIFF that didn't have an orientation tag, and I spotted I was getting a SetField error, rather than a GetField error.