### PR TITLE
Memory allocation fixes

### DIFF
--- a/Sources/LibTIFF/TIFFImage.swift
+++ b/Sources/LibTIFF/TIFFImage.swift
@@ -69,8 +69,8 @@ public class TIFFImage<Channel> : ImageProtocol {
             throw TIFFError.IncorrectChannelSize(attributes.bitsPerSample)
         }
         let size = Int(attributes.width) * Int(attributes.height)
-        let byteCount = size * Int(attributes.bitsPerSample)
-        self.buffer = UnsafeMutablePointer<Channel>.allocate(capacity: byteCount)
+        let elementCount = size * Int(attributes.samplesPerPixel)
+        self.buffer = UnsafeMutablePointer<Channel>.allocate(capacity: elementCount)
         try read()
     }
 
@@ -98,9 +98,8 @@ public class TIFFImage<Channel> : ImageProtocol {
                                          orientation: UInt32(ORIENTATION_TOPLEFT),
                                          extraSamples: extraSamples)
         let pixelCount = size.width * size.height
-        let byteCount = pixelCount * Int(attributes.bitsPerSample)
-        
-        self.buffer = UnsafeMutablePointer<Channel>.allocate(capacity: byteCount)
+        let elementCount = pixelCount * Int(attributes.samplesPerPixel)
+        self.buffer = UnsafeMutablePointer<Channel>.allocate(capacity: elementCount)
     }
 
     public init(size: Size, hasAlpha: Bool = false) {
@@ -123,8 +122,8 @@ public class TIFFImage<Channel> : ImageProtocol {
                                      orientation: UInt32(ORIENTATION_TOPLEFT),
                                      extraSamples: extraSamples)
         let pixelCount = size.width * size.height
-        let byteCount = pixelCount * Int(attributes.bitsPerSample)
-        self.buffer = UnsafeMutablePointer<Channel>.allocate(capacity: byteCount)
+        let elementCount = pixelCount * Int(attributes.samplesPerPixel)
+        self.buffer = UnsafeMutablePointer<Channel>.allocate(capacity: elementCount)
     }
 
 

--- a/Sources/LibTIFF/TIFFImage.swift
+++ b/Sources/LibTIFF/TIFFImage.swift
@@ -423,6 +423,7 @@ public struct TIFFAttributes {
         var count: UInt16 = 4
         typealias Ptr = UnsafeMutablePointer<UInt16>
         var buff: Ptr? = Ptr.allocate(capacity: Int(count))
+        defer { buff?.deallocate() }
         let result = TIFFGetField_ExtraSample(ref,
                                               &count,
                                               &buff)


### PR DESCRIPTION
Spotted whilst doing other work:

* bitsPerSample rather than samplesPerPixel was being used to allocate image memory. Thankfully this will almost always over allocate memory, so failed safe, but is somewhat wasteful.
* there was a missing deallocate in the code for extra_samples